### PR TITLE
Fix/feedback0512

### DIFF
--- a/src/common/components/VerticalLine.tsx
+++ b/src/common/components/VerticalLine.tsx
@@ -4,32 +4,32 @@ import styled from "@emotion/styled";
 
 import { theme } from "@krafton-soc/common/styles/theme";
 
-const HistoryCardBorderLine = styled.div<DividerLineProps>`
-  width: ${({ width }) => (width ? `${width}px` : "100%")};
-  height: 1px;
+const VerticalLineStyle = styled.div<VerticalLineProps>`
+  width: 1px;
+  height: ${({ height }) => (height ? `${height}px` : "100%")};
   background-color: ${({ color }) => color || theme.colors.dividerLine};
-  transform: scaleY(1); // 선을 균일하게 만들기 위해 추가
+  transform: scaleX(1); // 선을 균일하게 만들기 위해 추가
   margin-top: ${({ marginTop }) => (marginTop ? `${marginTop}px` : "0")};
   margin-bottom: ${({ marginBottom }) =>
     marginBottom ? `${marginBottom}px` : "0"};
 `;
 
-type DividerLineProps = {
-  width?: number;
+type VerticalLineProps = {
+  height?: number;
   color?: string;
   marginTop?: number;
   marginBottom?: number;
 };
 
-const DividerLine = ({
-  width,
+const VerticalLine = ({
+  height,
   color,
   marginTop,
   marginBottom,
-}: DividerLineProps) => {
+}: VerticalLineProps) => {
   return (
-    <HistoryCardBorderLine
-      width={width}
+    <VerticalLineStyle
+      height={height}
       color={color}
       marginTop={marginTop}
       marginBottom={marginBottom}
@@ -37,4 +37,4 @@ const DividerLine = ({
   );
 };
 
-export default DividerLine;
+export default VerticalLine;

--- a/src/features/building-journey/components/BuildingJourneyBanner.tsx
+++ b/src/features/building-journey/components/BuildingJourneyBanner.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from "next-intl";
 import React from "react";
 
 import Text from "@krafton-soc/common/components/Text";
+import VerticalLine from "@krafton-soc/common/components/VerticalLine";
 import { theme } from "@krafton-soc/common/styles/theme";
 
 const BannerContainer = styled.section`
@@ -16,7 +17,6 @@ const BannerContainer = styled.section`
   flex-direction: column;
   align-items: center;
   z-index: 0;
-  gap: 330px;
 `;
 
 const ImageContainer = styled.div`
@@ -114,6 +114,12 @@ const ChairmanMessage: React.FC = () => {
           />
         </BannerImage>
       </ImageContainer>
+      <VerticalLine
+        height={200}
+        color={theme.colors.black}
+        marginTop={70}
+        marginBottom={70}
+      />
       <ChairmanMessageContainer>
         <MessageContainer>
           <Text color={theme.colors.black}>{t("chairmanMessage.message")}</Text>

--- a/src/features/building-journey/frames/BuildingJourney.tsx
+++ b/src/features/building-journey/frames/BuildingJourney.tsx
@@ -10,7 +10,7 @@ const BuildingJourneyContainer = styled.main`
   flex-direction: column;
   align-items: center;
   gap: 333px;
-  margin-bottom: 74px;
+  margin-bottom: 130px;
   // background-color: pink;
 `;
 
@@ -19,7 +19,7 @@ const PartContainer = styled.div`
   flex-direction: column;
   align-items: center;
   gap: 170px;
-  padding-bottom: 57px;
+
   //background-color: orange;
 `;
 
@@ -72,7 +72,8 @@ const partContents = [
               startTerm: "01.20",
               endTerm: "03.16",
             },
-            title: "전산학부 증축 준비 논의",
+            title:
+              "KAIST 전산학부 증축 공간 활용 및 KRAFTON 연계 프로그램 논의",
             detail:
               "01.20 KAIST-KRAFTON 연계 활동 및 프로그램 추진 협의\n03.09-16 KAIST-KRAFTON 연계 활동 및 프로그램 구체화",
           },
@@ -157,6 +158,7 @@ const partContents = [
               src: "/images/building-journey/part2/20210507.png",
               alt: "학부 95학번 서하연, 96학번 한동훈 동문 부부 2,000만 원 기부 사진",
             },
+            link: "https://cs.kaist.ac.kr/board/view?bbs_id=news&bbs_sn=9680&menu=83",
           },
           {
             duration: {

--- a/src/features/building-journey/frames/BuildingJourney.tsx
+++ b/src/features/building-journey/frames/BuildingJourney.tsx
@@ -488,6 +488,7 @@ const BuildingJourney: React.FC = () => {
   return (
     <BuildingJourneyContainer>
       <BuildingJourneyBanner />
+
       <PartContainer>
         {partContents.map(part => (
           <BuildingJourneyPart key={part.part} {...part} />

--- a/src/features/design-story/components/DesignStoryConcept/DesignStoryConceptCard3.tsx
+++ b/src/features/design-story/components/DesignStoryConcept/DesignStoryConceptCard3.tsx
@@ -100,7 +100,7 @@ const DesignStoryConceptCard3 = () => {
           <Text>{`Heritage, \nNot a Narrative`}</Text>
         </CardTextTitle>
         <CardTextContent>
-          <Text>{`‘Heritage, Not a Narrative’는 이번 프로젝트를 \n관통하는 가장 중요한 개념이었습니다. \n기부자들이 자신의 존재를 부각시키기보다, 후배들에게 \n자연스럽게 유산을 남기고자 하는 의지를 담아 \n공간 속에서 은은하게 드러나도록 디자인했습니다.\n\n함께 성장하는 ‘Reflective Jungle’(가칭)의 식물 사이로 슈퍼미러에 새겨진 기부자의 메시지는 단순한 일방적인 기념물이 아니라, 사용자의 움직임에 따라 변화하고 \n투영되는 요소로 작용합니다.`}</Text>
+          <Text>{`‘Heritage, Not a Narrative’는 이번 프로젝트를 \n관통하는 가장 중요한 개념이었습니다. \n기부자들이 자신의 존재를 부각시키기보다, 후배들에게 \n자연스럽게 유산을 남기고자 하는 의지를 담아 \n공간 속에서 은은하게 드러나도록 디자인했습니다.\n\n함께 성장하는 ‘Reflective Jungle’의 식물 사이로 슈퍼미러에 새겨진 기부자의 메시지는 단순한 일방적인 기념물이 아니라, 사용자의 움직임에 따라 변화하고 \n투영되는 요소로 작용합니다.`}</Text>
         </CardTextContent>
       </CardTextContainer>
       <CardImageContainer>

--- a/src/features/design-story/components/DesignStoryConcept/DesignStoryConceptCard8.tsx
+++ b/src/features/design-story/components/DesignStoryConcept/DesignStoryConceptCard8.tsx
@@ -68,7 +68,7 @@ const DesignStoryConceptCard8 = () => {
         <CardRightText>
           <Text>
             {
-              "‘Along, A-long Table’(가칭)과 같은 오브제를 통해 \n유산(Legacy)의 지속성과 연속성이 테이블까지 이어지며, \n이를 사용하는 후배들에게 자연스럽게 전해지기를 바랐습니다."
+              "‘Along, A-long Table’과 같은 오브제를 통해 \n유산(Legacy)의 지속성과 연속성이 테이블까지 이어지며, \n이를 사용하는 후배들에게 자연스럽게 전해지기를 바랐습니다."
             }
           </Text>
         </CardRightText>

--- a/src/features/positive-impact/components/PositiveImpactMessage/PositiveImpactMessage.tsx
+++ b/src/features/positive-impact/components/PositiveImpactMessage/PositiveImpactMessage.tsx
@@ -17,7 +17,6 @@ const MessageContainer = styled.section`
 `;
 
 const MessageCardListContainer = styled.div`
-  margin-top: 145px;
   width: 100%;
 
   display: flex;
@@ -93,7 +92,7 @@ const PositiveImpactMessage = () => {
   return (
     <MessageContainer>
       <PositiveImpactMessageChief />
-      <DividerLine />
+      <DividerLine marginTop={100} marginBottom={145} />
       <MessageCardListContainer>
         <MessageCardContainer>
           <MessageCardImage>

--- a/src/features/positive-impact/components/PositiveImpactMessage/PositiveImpactMessageChief.tsx
+++ b/src/features/positive-impact/components/PositiveImpactMessage/PositiveImpactMessageChief.tsx
@@ -4,9 +4,6 @@ import Text from "@krafton-soc/common/components/Text";
 import { theme } from "@krafton-soc/common/styles/theme";
 
 const ChiefContainer = styled.section`
-  margin-top: 186px;
-  margin-bottom: 186px;
-
   width: 100%;
 
   display: flex;

--- a/src/features/positive-impact/frames/PositiveImpact.tsx
+++ b/src/features/positive-impact/frames/PositiveImpact.tsx
@@ -2,6 +2,9 @@
 
 import styled from "@emotion/styled";
 
+import VerticalLine from "@krafton-soc/common/components/VerticalLine";
+import { theme } from "@krafton-soc/common/styles/theme";
+
 import PositiveImpactBanner from "../components/PositiveImpactBanner";
 import PositiveImpactDonner from "../components/PositiveImpactDonner";
 import PositiveImpactMessage from "../components/PositiveImpactMessage";
@@ -18,6 +21,12 @@ const PositiveImpact = () => {
   return (
     <PositiveImpactContainer>
       <PositiveImpactBanner />
+      <VerticalLine
+        height={150}
+        color={theme.colors.black}
+        marginTop={65}
+        marginBottom={65}
+      />
       <PositiveImpactMessage />
       <PositiveImpactDonner />
     </PositiveImpactContainer>


### PR DESCRIPTION
5월 12일자 피드백에 대한 수정


[텍스트 및 링크, 일부 수정 부분]
주신 PC화면 확인하면서 일주 텍스트 수정이 필요하거나 링크 빠진 부분이 있어서 아래에 이미지와 함께 적어드려요.
건립의 여정
   - Part1. 2021.01.20-03.16 부분
     '전산학부 증축 준비 논의'가 아닌 'KAIST 전산학부 증축 공간 활용 및 KRAFTON 연계 프로그램 논의' 입니다.
   - Part2. 05.06 서하연 부부님 기부 부분
      링크가 누락되었습니다.
   - '선한 영향력의 길'과 동일하게 콘텐츠 끝나는 지점과 푸터와의 여백이 130px정도였으면 좋겠습니다.
     (단위를 픽셀로 전달드려도 될지 고민되었지만 말씀드려요~)
   - 최상단 부분 여백이 어색하여 바를 추가하였습니다.. :yotsuba_09:
      (디자인 수정이 없을거라 했지만 부탁드려요...)
2. 디자인 이야기
본문의 내용 중 (가칭)이라고 기재된 부분의 (가칭) 삭제 부탁드립니다.
 * 가칭이었으나 최종 네이밍으로 확정되었어요.
3. 선한 영향력의 길
      - '선한 영향력의 길'과 동일하게 콘텐츠 끝나는 지점과 푸터와의 여백이 130px정도였으면 좋겠습니다.
     (단위를 픽셀로 전달드려도 될지 고민되었지만 말씀드려요~)
   - 최상단 부분 여백이 어색하여 바를 추가하였습니다.. :yotsuba_09:
      (디자인 수정이 없을거라 했지만 부탁드려요...)
      
    